### PR TITLE
Adds new arguments for the utility scripts, build_image and jinkies

### DIFF
--- a/Docker/build_image
+++ b/Docker/build_image
@@ -5,18 +5,21 @@ cd ${THIS_SCRIPT_DIR}
 
 THIS_SCRIPT_NAME=$(basename $0)
 ENV_FILE="${THIS_SCRIPT_DIR}/build.env"
+NO_CACHE=""
 
 function usage() {
   cat <<EOS
   Usage: ${THIS_SCRIPT_NAME} - builds the container
   Arguments:
-    -v -- Version number to tag the build with. Defaults to latest.
+    -v            -- Version number to tag the build with. Defaults to latest.
+    --no-cache    -- Pass the --no-cache flag through to docker build
 EOS
 }
 
 for arg in $@
 do
   case $arg in
+    "--no-cache"       )  NO_CACHE="--no-cache"; shift;;
     "--env-file"       )  shift; ENV_FILE=$arg; shift;;
     "-h" | "--help"    )  show_help="true"; shift;;
   esac
@@ -34,7 +37,7 @@ else
   exit 1
 fi
 
-docker build -t "${IMAGE_TAG}:${IMAGE_VERSION}" . --build-arg casc_jenkins_config="${CASC_JENKINS_CONFIG}" \
+docker build ${NO_CACHE} -t "${IMAGE_TAG}:${IMAGE_VERSION}" . --build-arg casc_jenkins_config="${CASC_JENKINS_CONFIG}" \
                                                   --build-arg jenkins_home="${JENKINS_HOME}" \
                                                   --build-arg jenkins_java_opts="${JENKINS_JAVA_OPTS}"
 

--- a/jinkies
+++ b/jinkies
@@ -8,6 +8,7 @@ source Docker/build.env
 show_help="false"
 start="false"
 stop="false"
+logs="false"
 
 if [[ ${#@} -lt 1 ]]; then
   show_help="true"
@@ -16,6 +17,7 @@ fi
 for arg in $@
 do
   case $arg in
+    "--logs"      )  logs="true"; shift;;
     "--start"     )  start="true"; shift;;
     "--stop"     )  stop="true"; shift;;
     "-h" | "--help"    )  show_help="true"; shift;;
@@ -25,6 +27,8 @@ done
 if [[ "${show_help}" == "true" ]]; then
   echo "Usage: ${0} --start   Starts the container. Takes place before a --stop."
   echo "       ${0} --stop   Stops and deletes the container"
+  echo "       ${0} --logs   run 'docker logs' for the container"
+
   exit 0
 fi
 
@@ -36,4 +40,8 @@ fi
 
 if [[ ${stop} == "true" ]]; then
   docker container stop ${CONTAINER_SHORT_NAME}
+fi
+
+if [[ ${logs} == "true" ]]; then
+  docker logs -f ${CONTAINER_SHORT_NAME}
 fi


### PR DESCRIPTION
build_image: --no-cache is added, to forcibly remove the build cache
and rebuild an image from scratch.
jinkies:     --logs is added to run 'docker logs -f' on the jinkies
container

[x] You have revved build.env's IMAGE_VERSION if needed.

[x] You have updated documentation supporting users that do not know how to use this
