### PR TITLE
Makes all RAM usage explicit.

### DIFF
--- a/Docker/build.env
+++ b/Docker/build.env
@@ -16,5 +16,12 @@ IMAGE_TAG=playtechnique.io/jinkies
 # The portion of the docker image tag after the colon
 IMAGE_VERSION=0.0.0
 
+# These are the values for the lowest and highest marks for the Jenkins JVM
+# Change them to anything, but they have to be in Jenkins JVM Options units
+JVM_SMALL_HEAP=1G
+JVM_LARGE_HEAP=2G
+
+DOCKER_CONTAINER_RAM=${JVM_LARGE_HEAP}
+
 # JAVA_OPTS set in the environment that jenkins.jar runs in.
-JENKINS_JAVA_OPTS="-Djenkins.install.runSetupWizard=false -Xms2048m -Xmx4056m"
+JENKINS_JAVA_OPTS="-Djenkins.install.runSetupWizard=false -Xms${JVM_SMALL_HEAP} -Xmx${JVM_LARGE_HEAP}"

--- a/jinkies
+++ b/jinkies
@@ -33,7 +33,7 @@ if [[ "${show_help}" == "true" ]]; then
 fi
 
 if [[ ${start} == "true" ]]; then
-  docker run -d --rm -p ${HOST_JENKINS_PORT}:${CONTAINER_JENKINS_PORT} --name ${CONTAINER_SHORT_NAME} ${IMAGE_TAG}:${IMAGE_VERSION}
+  docker run --memory $DOCKER_CONTAINER_RAM -d --rm -p ${HOST_JENKINS_PORT}:${CONTAINER_JENKINS_PORT} --name ${CONTAINER_SHORT_NAME} ${IMAGE_TAG}:${IMAGE_VERSION}
   echo "http://localhost:${HOST_JENKINS_PORT}"
 fi
 


### PR DESCRIPTION
I extracted the jvm heap settings, reasoning that the high end for the
linux container should be assigned explicitly.

[x] You have revved build.env's IMAGE_VERSION if needed.

[x] You have updated documentation supporting users that do not know how to use this
